### PR TITLE
build(dependabot.yml): add a dependency watchfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+
+#  # Maintain Python dependencies
+#  - package-ecosystem: "pip"  # i.e. updates only in `pyproject.toml`
+#    directory: "/"
+#    schedule:
+#      interval: "monthly"
+#    groups:
+#      pip:
+#        patterns:
+#          - "*"
+#    cooldown:
+#      default-days: 7


### PR DESCRIPTION
To ease future maintenance of depedencies, a dependabot watchfile is added.  For now, only active on GitHub actions (GHA) because the project isn't organized around a pyproject.toml file.